### PR TITLE
Fix stray closing tag in education section

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,6 @@
   </div>
 </div>
     </div>
-  </div>
 </section>
 
     <!-- Contact -->


### PR DESCRIPTION
## Summary
- remove an extra closing `div` from the Education section

## Testing
- `python3 - <<'EOF' ... EOF`

------
https://chatgpt.com/codex/tasks/task_e_6886a572da088324ae0ec7fc97ecf547